### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize Terraform and YAML files to LF
+*.tf   text eol=lf
+*.yaml text eol=lf
+*.yml  text eol=lf


### PR DESCRIPTION
On Windows, if Git isn’t configured for consistent line endings core.autocrlf, it may automatically convert LF to CRLF on checkout. If main.tf ends up with CRLF, the metadata startup script may not execute correctly. To avoid this, we should enforce LF via .gitattributes for *.tf, *.yaml, *.yml.