### PR TITLE
Send local env_vars as a string instead of map to GCP metadata

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,9 @@ resource "google_compute_instance" "instance" {
     access_config {}
   }
 
-  metadata = local.env_vars
+  metadata = {
+    user_data_map = jsonencode(local.env_vars)
+  }
 
   metadata_startup_script = <<-EOF
     #!/bin/bash


### PR DESCRIPTION
We need this to bypass GCP's restriction on dots ('.') in some metadata keys we use