### PR TITLE
GCP TF: add static/ephemeral IP, Let's Encrypt, and deletion protecti…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,8 @@ resource "google_compute_instance" "instance" {
     }
   }
 
-  can_ip_forward = var.ip_forward
+  can_ip_forward      = var.ip_forward
+  deletion_protection = var.deletion_protection
 
   network_interface {
     subnetwork = local.create_vpc ? google_compute_subnetwork.subnet[0].id : data.google_compute_subnetwork.existing_subnet[0].id

--- a/main.tf
+++ b/main.tf
@@ -35,11 +35,14 @@ resource "google_compute_instance" "instance" {
   network_interface {
     subnetwork = local.create_vpc ? google_compute_subnetwork.subnet[0].id : data.google_compute_subnetwork.existing_subnet[0].id
 
-    access_config {}
+    access_config {
+      nat_ip = var.enable_static_ip ? google_compute_address.static_ip[0].address : null
+    }
   }
 
   metadata = {
-    user_data_map = jsonencode(local.env_vars)
+    user_data_map      = jsonencode(local.env_vars)
+    enable_letsencrypt = tostring(var.enable_letsencrypt)
   }
 
   metadata_startup_script = <<-EOF
@@ -49,19 +52,35 @@ resource "google_compute_instance" "instance" {
         exit 0
     fi
 
-    bash -c 'OVPN_INIT_MANUAL=true bash <(curl -fsS https://packages.openvpn.net/as/install.sh) --yes --as-version=3.1.0'
+    echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean true | debconf-set-selections
+    dpkg-reconfigure -f noninteractive unattended-upgrades
+
+    bash -c 'OVPN_INIT_MANUAL=true bash <(curl -fsS https://packages.openvpn.net/as/install.sh) --yes --as-version=3.2.2'
     apt-mark hold openvpn-as
 
     /usr/bin/ovpn-init --gcp --batch --force
 
-    until sacli status 2>/dev/null |grep -q '"api": "on"'
+    until sacli status 2>/dev/null | grep -q '"api": "on"'
     do
         sleep 2
     done
     sacli --key "dnsproxy.mode" --value "always" ConfigPut
     sacli --key "vpn.client.routing.reroute_dns" --value "true" ConfigPut
     sacli --key "vpn.client.routing.reroute_gw" --value "true" ConfigPut
+
+    ENABLE_LETSENCRYPT=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/enable_letsencrypt")
+    if [ "$ENABLE_LETSENCRYPT" = "true" ]; then
+        PUBLIC_IP=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip")
+        sacli --key "acme.ip_addresses.0" --value "$PUBLIC_IP" ConfigPut
+        sacli --key "acme.cert_profile" --value "shortlived" ConfigPut
+    fi
+
     sacli start
+
+    if [ "$ENABLE_LETSENCRYPT" = "true" ]; then
+        echo y | sacli AcmeRegisterAccount
+        sacli AcmeRequestCertificate
+    fi
 
     . /usr/local/openvpn_as/etc/VERSION
 
@@ -71,6 +90,8 @@ resource "google_compute_instance" "instance" {
 echo "Welcome to OpenVPN Access Server Appliance $AS_VERSION"
 HEADER
   EOF
+
+  depends_on = [google_compute_firewall.tcp_443]
 }
 
 resource "google_compute_firewall" "tcp_443" {

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -36,6 +36,16 @@ spec:
           name: deletion_protection
           title: Enable deletion protection
           invisible: true
+        enable_letsencrypt:
+          name: enable_letsencrypt
+          title: Enable Let's Encrypt certificate
+          tooltip: Automatically request a trusted TLS certificate bound to this instance's public IP address. Requires TCP port 443 to stay open (see "Allow HTTPS" below). If the public IP later changes, the certificate must be re-requested manually.
+          section: networking
+        enable_static_ip:
+          name: enable_static_ip
+          title: Use a static external IP address
+          tooltip: Recommended, especially with Let's Encrypt enabled - an ephemeral IP can change when the instance is stopped and started, which invalidates an issued certificate.
+          section: networking
         enable_tcp_22:
           name: enable_tcp_22
           title: Allow TCP port 22 (SSH traffic)

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -18,6 +18,7 @@ spec:
         boot_disk_size:
           name: boot_disk_size
           title: Boot disk size in GB
+          min: 20
           max: 10000
           section: boot_disk
           xGoogleProperty:

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -91,8 +91,8 @@ spec:
           xGoogleProperty:
             type: ET_GCE_DISK_IMAGE
           enumValueLabels:
-            - label: ubuntu-2404-20260122
-              value: projects/openvpn-access-server-200800/global/images/ubuntu-2404-20260122
+            - label: ubuntu-2404-lts-amd64
+              value: ubuntu-os-cloud/ubuntu-2404-lts-amd64
         subnet_ip_cidr_range:
           name: subnet_ip_cidr_range
           title: Subnet Ip Cidr Range

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -31,6 +31,10 @@ spec:
           xGoogleProperty:
             type: ET_GCE_DISK_TYPE
             zoneProperty: zone
+        deletion_protection:
+          name: deletion_protection
+          title: Enable deletion protection
+          invisible: true
         enable_tcp_22:
           name: enable_tcp_22
           title: Allow TCP port 22 (SSH traffic)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -102,7 +102,7 @@ spec:
         varType: string
         defaultValue: ""
       - name: enable_tcp_22
-        description: Allow HTTPS (VPN traffic)
+        description: Allow TCP port 22 (SSH traffic)
         varType: bool
         defaultValue: true
       - name: tcp_22_source_ranges

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -73,6 +73,10 @@ spec:
         description: Whether to allow sending and receiving of packets with non-matching source or destination IPs.
         varType: bool
         defaultValue: false
+      - name: deletion_protection
+        description: Whether to enable deletion protection on the VM instance. When true, the instance cannot be deleted until this is set back to false.
+        varType: bool
+        defaultValue: false
       - name: enable_tcp_443
         description: Allow HTTPS (VPN traffic)
         varType: bool

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,11 +12,54 @@ spec:
       repo: https://github.com/OpenVPN/openvpn-as-gcp-terraform-deploy.git
       sourceType: git
       dir: /
-    version: 3.0.1
+    version: 3.2.2
     actuationTool:
       flavor: Terraform
       version: ">= 1.2"
-    description: {}
+    description:
+      tagline: Self-hosted business VPN and Zero Trust Network Access from the creators of OpenVPN
+      detailed: |-
+        Access Server is a self-hosted business VPN and Zero Trust Network Access (ZTNA) software
+        solution developed by the creators of the OpenVPN protocol. It gives your remote, hybrid,
+        and in-office workforce protected access to VPC networks, private subnets, Cloud SQL
+        instances, GKE clusters, and on-premises resources, without surrendering control of your
+        infrastructure to a third-party service.
+
+        This deployment runs Access Server on a single Compute Engine VM running Ubuntu 24.04 LTS,
+        within your own project and VPC network. Access Server is managed through a web-based
+        Admin Web UI, with REST API and command-line configuration options for advanced
+        administration, plus a client web portal for end users to download pre-configured
+        connection profiles.
+
+        Access Server supports Zero Trust access controls, including a Zero Trust Application
+        Broker that scopes each connection to a single authorized app; flexible authentication
+        with local accounts, PAM, RADIUS, LDAP, and SAML single sign-on with providers such as
+        Google Workspace, Cloud Identity, Okta, and Microsoft Entra ID, plus built-in MFA via
+        TOTP; and OpenVPN Data Channel Offload (DCO) for kernel-accelerated VPN throughput.
+
+        The deployment creates a VPC network and subnet, or attaches to an existing VPC and
+        subnet you specify. Firewall rules for the VPN, admin GUI, and SSH ports are created
+        individually and can each be disabled or restricted to specific source IP ranges. A
+        static external IP address and a Let's Encrypt TLS certificate for that address can
+        optionally be provisioned.
+      preDeploy: |-
+        Access Server is installed at first boot from packages.openvpn.net, so the instance
+        requires outbound internet access.
+
+        The generated admin password is shown in the deployment outputs. Open the Admin Web UI,
+        sign in with the temporary credentials, change the password, and accept the End User
+        License Agreement.
+
+        Enabling the Let's Encrypt option requires TCP port 443 to remain open and reachable
+        from the internet so the certificate authority can validate the instance. A static
+        external IP address is strongly recommended alongside it, because an ephemeral IP can
+        change when the instance is stopped and started, which invalidates an issued certificate.
+        If Let's Encrypt is disabled or fails to issue a certificate, the Admin Web UI falls back
+        to a self-signed certificate and browsers will show a warning until you configure your
+        own SSL certificate.
+
+        Access Server requires a subscription or license key for more than two simultaneous VPN
+        connections.
     softwareGroups:
       - type: SG_OS
         software:
@@ -77,6 +120,10 @@ spec:
         description: Whether to enable deletion protection on the VM instance. When true, the instance cannot be deleted until this is set back to false.
         varType: bool
         defaultValue: false
+      - name: enable_static_ip
+        description: Assign a static external IP address to the VM instance. Recommended, especially with 'enable_letsencrypt' - ephemeral IP addresses can change when the instance is stopped and started, invalidating an issued certificate.
+        varType: bool
+        defaultValue: true
       - name: enable_tcp_443
         description: Allow HTTPS (VPN traffic)
         varType: bool
@@ -85,6 +132,10 @@ spec:
         description: Source IP ranges for HTTPS traffic
         varType: string
         defaultValue: ""
+      - name: enable_letsencrypt
+        description: Automatically request and install a Let's Encrypt TLS certificate for the instance's public IP address. Requires 'enable_tcp_443' to remain true.
+        varType: bool
+        defaultValue: true
       - name: enable_tcp_943
         description: Allow TCP port 943 (Admin/User GUI traffic)
         varType: bool

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,7 +36,7 @@ spec:
       - name: source_image
         description: The image name for the disk for the VM instance.
         varType: string
-        defaultValue: projects/openvpn-access-server-200800/global/images/ubuntu-2404-20260122
+        defaultValue: ubuntu-os-cloud/ubuntu-2404-lts-amd64
       - name: region
         description: The region for the solution to be deployed.
         varType: string

--- a/network.tf
+++ b/network.tf
@@ -26,3 +26,9 @@ resource "google_compute_subnetwork" "subnet" {
   network       = google_compute_network.vpc[0].id
   ip_cidr_range = var.subnet_ip_cidr_range
 }
+
+resource "google_compute_address" "static_ip" {
+  count  = var.enable_static_ip ? 1 : 0
+  name   = "${var.goog_cm_deployment_name}-static-ip"
+  region = var.region
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,9 +13,7 @@ variable "goog_cm_deployment_name" {
 variable "source_image" {
   description = "The image name for the disk for the VM instance."
   type        = string
-  // Ubuntu 24.04 image with BYOL for GCP Marketplace
-  // For Terraform deployments any Access Server supported image can be used
-  default     = "projects/openvpn-access-server-200800/global/images/ubuntu-2404-20260319"
+  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 }
 
 variable "region" {

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "deletion_protection" {
   default     = false
 }
 
+variable "enable_static_ip" {
+  description = "Assign a static external IP address to the VM instance. Recommended, especially with 'enable_letsencrypt' - ephemeral IP addresses can change when the instance is stopped and started, invalidating an issued certificate."
+  type        = bool
+  default     = true
+}
+
 variable "enable_tcp_443" {
   description = "Allow HTTPS (VPN traffic)"
   type        = bool
@@ -86,6 +92,12 @@ variable "tcp_443_source_ranges" {
   description = "Source IP ranges for HTTPS traffic"
   type        = string
   default     = ""
+}
+
+variable "enable_letsencrypt" {
+  description = "Automatically request and install a Let's Encrypt TLS certificate for the instance's public IP address. Requires 'enable_tcp_443' to remain true."
+  type        = bool
+  default     = true
 }
 
 variable "enable_tcp_943" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "ip_forward" {
   default     = false
 }
 
+variable "deletion_protection" {
+  description = "Whether to enable deletion protection on the VM instance. When true, the instance cannot be deleted until this is set back to false."
+  type        = bool
+  default     = false
+}
+
 variable "enable_tcp_443" {
   description = "Allow HTTPS (VPN traffic)"
   type        = bool


### PR DESCRIPTION

- Add enable_static_ip variable (default true) and a google_compute_address resource so the instance's external IP can be reserved as static instead of ephemeral
- Add enable_letsencrypt variable (default true); startup script requests a Let's Encrypt certificate via sacli ACME commands once Access Server is up
- Add deletion_protection variable (Terraform-only, hidden from the Marketplace UI). Closes #7
- Enable unattended-upgrades on first boot
- Switch source_image default to the public Ubuntu 24.04 LTS image family
- Update metadata.yaml/metadata.display.yaml to expose the new options in the Marketplace deployment UI